### PR TITLE
chore: remove Kotlin/JS compiler property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 #Kotlin
 kotlin.code.style=official
-kotlin.js.compiler=ir
 #MPP
 kotlin.mpp.enableCInteropCommonization=true
 #Android


### PR DESCRIPTION
## Overview
Removed the deprecated `kotlin.js.compiler` Gradle property.  
The property is deprecated and no longer supported in recent Kotlin versions, IR is now the default compiler.

No functional changes.

## Related Issue
Resolves #30 